### PR TITLE
Fix the version of node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-quintype",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Gulp Tools for Quintype Apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gulp-minify": "0.0.14",
     "gulp-rev": "^7.1.2",
     "gulp-rev-replace": "^0.4.3",
-    "node-sass": "^4.5.0",
+    "node-sass": "4.8.2",
     "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^2.0.0",


### PR DESCRIPTION
`node-sass` 4.8.3 has issues with npm 3 and causes a segmentation fault.

Changed to install only 4.8.2 version instead of latest 4.8.3